### PR TITLE
V3/dev fixes (#288)

### DIFF
--- a/bodyprocessors/multipart.go
+++ b/bodyprocessors/multipart.go
@@ -48,6 +48,7 @@ func (_ *multipartBodyProcessor) ProcessRequest(reader io.Reader, collections [t
 	fileSizesCol := (collections[variables.FilesSizes]).(*collection.CollectionMap)
 	postCol := (collections[variables.ArgsPost]).(*collection.CollectionMap)
 	filesCombinedSizeCol := (collections[variables.FilesCombinedSize]).(*collection.CollectionSimple)
+	filesNamesCol := (collections[variables.FilesNames]).(*collection.CollectionMap)
 	for {
 		p, err := mr.NextPart()
 		if err == io.EOF {
@@ -72,6 +73,7 @@ func (_ *multipartBodyProcessor) ProcessRequest(reader io.Reader, collections [t
 			filesCol.Add("", filename)
 			filesTmpNamesCol.Add("", temp.Name())
 			fileSizesCol.SetIndex(filename, 0, fmt.Sprintf("%d", sz))
+			filesNamesCol.Add("", p.FormName())
 		} else {
 			// if is a field
 			data, err := io.ReadAll(p)

--- a/collection/collection_map.go
+++ b/collection/collection_map.go
@@ -16,7 +16,6 @@ package collection
 
 import (
 	"regexp"
-	"strings"
 
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
@@ -35,7 +34,7 @@ type CollectionMap struct {
 // Get returns a slice of strings for a key
 func (c *CollectionMap) Get(key string) []string {
 	values := []string{}
-	for _, a := range c.data[strings.ToLower(key)] {
+	for _, a := range c.data[key] {
 		values = append(values, a.Value)
 	}
 	return values
@@ -214,6 +213,18 @@ func (c *CollectionMap) Reset() {
 	c.data = map[string][]types.AnchoredVar{
 		"": {},
 	}
+}
+
+// Data returns all the data in the CollectionMap
+func (c *CollectionMap) Data() map[string][]string {
+	result := map[string][]string{}
+	for k, v := range c.data {
+		result[k] = []string{}
+		for _, a := range v {
+			result[k] = append(result[k], a.Value)
+		}
+	}
+	return result
 }
 
 var _ Collection = &CollectionMap{}

--- a/collection/collection_proxy.go
+++ b/collection/collection_proxy.go
@@ -62,6 +62,15 @@ func (c *CollectionProxy) Name() string {
 	return c.name
 }
 
+// Get returns the data for the key
+func (c *CollectionProxy) Get(key string) []string {
+	res := []string{}
+	for _, c := range c.data {
+		res = append(res, c.Get(key)...)
+	}
+	return res
+}
+
 // Reset the current CollectionProxy
 func (c *CollectionProxy) Reset() {
 }

--- a/collection/collection_translation_proxy.go
+++ b/collection/collection_translation_proxy.go
@@ -90,6 +90,15 @@ func (c *CollectionTranslationProxy) Reset() {
 	// do nothing
 }
 
+func (c *CollectionTranslationProxy) Get(index int) string {
+	if index < len(c.data) {
+		if v := c.data[index].Get(""); len(v) > 0 {
+			return v[0]
+		}
+	}
+	return ""
+}
+
 var _ Collection = &CollectionTranslationProxy{}
 
 func NewCollectionTranslationProxy(variable variables.RuleVariable, data ...*CollectionMap) *CollectionTranslationProxy {

--- a/testdata/engine/disruptive_actions.yaml
+++ b/testdata/engine/disruptive_actions.yaml
@@ -1,0 +1,164 @@
+---
+  meta:
+    author: sts
+    description: Test if disruptive actions trigger an interruption
+    enabled: true
+    name: disruptive_actions.yaml
+  tests:
+  -
+    test_title: disruptive_actions
+    stages:
+    -
+      # Phase 1
+      stage:
+        input:
+            uri: /deny1
+        output:
+          triggered_rules:
+            - 2
+          interruption:
+            status: 500
+            data: ""
+            rule_id: 2
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop1
+        output:
+          triggered_rules:
+            - 3
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 3
+            action: drop
+    -
+      # Phase 2
+      stage:
+        input:
+            uri: /deny2
+        output:
+          triggered_rules:
+            - 22
+          interruption:
+            status: 500
+            data:
+            rule_id: 22
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop2
+        output:
+          triggered_rules:
+            - 23
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 23
+            action: drop
+      # Phase 3
+    -
+      stage:
+        input:
+            uri: /deny3
+        output:
+          triggered_rules:
+            - 32
+          interruption:
+            status: 500
+            data:
+            rule_id: 32
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop3
+        output:
+          triggered_rules:
+            - 33
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 33
+            action: drop
+    -
+      stage:
+        input:
+            uri: /deny4
+        output:
+          triggered_rules:
+            - 42
+          interruption:
+            status: 500
+            data:
+            rule_id: 42
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop4
+        output:
+          triggered_rules:
+            - 43
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 43
+            action: drop
+    -
+      stage:
+        input:
+            uri: /deny5
+        output:
+          triggered_rules:
+            - 52
+          interruption:
+            status: 500
+            data:
+            rule_id: 52
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop5
+        output:
+          triggered_rules:
+            - 53
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 53
+            action: drop
+    -
+      stage:
+        input:
+            uri: /default/block
+        output:
+          triggered_rules:
+            - 103
+          log_contains: "WOOOP_BLOCKED_BY_CORAZA_TEST"
+          interruption:
+            status: 501
+            data: ""
+            rule_id: 103
+            action: deny
+  rules: |
+    SecRule REQUEST_URI "/deny1$" "phase:1,id:2,log,status:500,deny"
+    SecRule REQUEST_URI "/drop1$" "phase:1,id:3,log,drop"
+
+    SecRule REQUEST_URI "/deny2$" "phase:2,id:22,log,status:500,deny"
+    SecRule REQUEST_URI "/drop2$" "phase:2,id:23,log,drop"
+
+    SecRule REQUEST_URI "/deny3$" "phase:3,id:32,log,status:500,deny"
+    SecRule REQUEST_URI "/drop3$" "phase:3,id:33,log,drop"
+
+    SecRule REQUEST_URI "/deny4$" "phase:4,id:42,log,status:500,deny"
+    SecRule REQUEST_URI "/drop4$" "phase:4,id:43,log,drop"
+
+    SecRule REQUEST_URI "/deny5$" "phase:5,id:52,log,status:500,deny"
+    SecRule REQUEST_URI "/drop5$" "phase:5,id:53,log,drop"
+
+    SecDefaultAction phase:2,deny,status:501,log,logdata:'WOOOP_BLOCKED_BY_CORAZA_TEST'
+    SecRule REQUEST_URI "/default/block" "id:103,block"

--- a/testing/coraza_test.go
+++ b/testing/coraza_test.go
@@ -38,16 +38,33 @@ func TestEngine(t *testing.T) {
 			t.Error(err)
 		}
 		for _, test := range tt {
-			if err := test.RunPhases(); err != nil {
-				t.Error(err)
-			}
-			for _, e := range test.OutputErrors() {
-				debug := ""
-				for _, mr := range test.transaction.MatchedRules {
-					debug += fmt.Sprintf(" %d", mr.Rule.ID)
+			testname := profile.Tests[0].Title
+
+			t.Run(testname, func(t *testing.T) {
+				if err := test.RunPhases(); err != nil {
+					t.Errorf("%s, ERROR: %s", test.Name, err)
 				}
-				t.Errorf("%s - %s: %s\nGot: %s\n%s\nREQUEST:\n%s", profile.Meta.Name, test.Name, e, debug, test.String(), test.Request())
-			}
+
+				for _, e := range test.OutputErrors() {
+					debug := ""
+					for _, mr := range test.transaction.MatchedRules {
+						debug += fmt.Sprintf(" %d", mr.Rule.ID)
+					}
+					if testing.Verbose() {
+						t.Errorf("\x1b[41m ERROR \x1b[0m: %s:%s: %s, got:%s\n%s\nREQUEST:\n%s", profile.Meta.Name, test.Name, e, debug, test.String(), test.Request())
+					} else {
+						t.Errorf("%s: ERROR: %s", test.Name, e)
+					}
+				}
+
+				for _, e := range test.OutputInterruptionErrors() {
+					if testing.Verbose() {
+						t.Errorf("\x1b[41m ERROR \x1b[0m: %s:%s: %s\n %s\nREQUEST:\n%s", profile.Meta.Name, test.Name, e, test.String(), test.Request())
+					} else {
+						t.Errorf("%s: ERROR: %s", test.Name, e)
+					}
+				}
+			})
 		}
 	}
 }

--- a/testing/engine.go
+++ b/testing/engine.go
@@ -22,16 +22,19 @@ import (
 	"strconv"
 	"strings"
 
-	engine "github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/collection"
+	"github.com/corazawaf/coraza/v3/types"
+	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 // Test represents a unique transaction within
 // a WAF instance for a test case
 type Test struct {
 	// waf contains a waf instance pointer
-	waf *engine.Waf
+	waf *coraza.Waf
 	// transaction contains the current transaction
-	transaction *engine.Transaction
+	transaction *coraza.Transaction
 	magic       bool
 	Name        string
 	body        string
@@ -64,7 +67,7 @@ type Test struct {
 }
 
 // SetWaf sets the waf instance pointer
-func (t *Test) SetWaf(waf *engine.Waf) {
+func (t *Test) SetWaf(waf *coraza.Waf) {
 	t.waf = waf
 }
 
@@ -190,8 +193,38 @@ func (t *Test) RunPhases() error {
 	return nil
 }
 
-// OutputErrors returns a list of errors
-// that occurred during the test
+// OutputInterruptionErrors returns a list of errors
+// that occured when comparing the interruption result
+func (t *Test) OutputInterruptionErrors() []string {
+	var errors []string
+
+	if t.ExpectedOutput.Interruption != nil {
+		if t.ExpectedOutput.Interruption.Action != t.transaction.Interruption.Action {
+			errors = append(errors, fmt.Sprintf("Interruption.Action: expected: '%s', got: '%s'",
+				t.ExpectedOutput.Interruption.Action, t.transaction.Interruption.Action))
+		}
+
+		if t.ExpectedOutput.Interruption.Status != t.transaction.Interruption.Status {
+			errors = append(errors, fmt.Sprintf("Interruption.Status: expected: '%d', got: '%d'",
+				t.ExpectedOutput.Interruption.Status, t.transaction.Interruption.Status))
+		}
+
+		if t.ExpectedOutput.Interruption.Data != t.transaction.Interruption.Data {
+			errors = append(errors, fmt.Sprintf("Interruption.Data: expected: '%s', got: '%s'",
+				t.ExpectedOutput.Interruption.Data, t.transaction.Interruption.Data))
+		}
+
+		if t.ExpectedOutput.Interruption.RuleID != t.transaction.Interruption.RuleID {
+			errors = append(errors, fmt.Sprintf("Interruption.RuleID: expected: '%d', got: '%d'",
+				t.ExpectedOutput.Interruption.RuleID, t.transaction.Interruption.RuleID))
+		}
+	}
+
+	return errors
+}
+
+// OutputErrors returns a list of errors that occurred during
+// the test when comparing log and rule ids
 func (t *Test) OutputErrors() []string {
 	var errors []string
 	if lc := t.ExpectedOutput.LogContains; lc != "" {
@@ -237,7 +270,7 @@ func (t *Test) LogContains(log string) bool {
 }
 
 // Transaction returns the transaction
-func (t *Test) Transaction() *engine.Transaction {
+func (t *Test) Transaction() *coraza.Transaction {
 	return t.transaction
 }
 
@@ -245,14 +278,49 @@ func (t *Test) Transaction() *engine.Transaction {
 // for debugging
 func (t *Test) String() string {
 	tx := t.transaction
-	res := "\n======ERRORLOG======\n"
+	res := "\n\n----------------------- ERRORLOG ----------------------\n"
 	for _, mr := range tx.MatchedRules {
 		res += mr.ErrorLog(t.ResponseCode)
-		res += "======MatchData======\n"
+		res += "\n\n----------------------- MATCHDATA ---------------------\n"
 		for _, md := range mr.MatchedDatas {
 			res += fmt.Sprintf("%+v", md) + "\n"
 		}
 		res += "\n"
+	}
+
+	res += "\n------------------------ DEBUG ------------------------\n"
+	for v := byte(1); v < types.VariablesCount; v++ {
+		vr := variables.RuleVariable(v)
+		if vr.Name() == "UNKNOWN" {
+			break
+		}
+		data := map[string][]string{}
+		switch col := tx.Collections[vr].(type) {
+		case *collection.CollectionSimple:
+			data[""] = []string{
+				col.String(),
+			}
+		case *collection.CollectionMap:
+			data = col.Data()
+		case *collection.CollectionProxy:
+			// data = col.Data()
+		case *collection.CollectionTranslationProxy:
+			// data = col.Data()
+		}
+
+		if len(data) == 1 {
+			res += fmt.Sprintf("%s: ", vr.Name())
+		} else {
+			res += fmt.Sprintf("%s:\n", vr.Name())
+		}
+
+		for k, d := range data {
+			if k != "" {
+				res += fmt.Sprintf("    %s: %s\n", k, strings.Join(d, ","))
+			} else {
+				res += fmt.Sprintf("%s\n", strings.Join(d, ","))
+			}
+		}
 	}
 	return res
 }
@@ -271,7 +339,7 @@ func (t *Test) Request() string {
 }
 
 // NewTest creates a new test with default properties
-func NewTest(name string, waf *engine.Waf) *Test {
+func NewTest(name string, waf *coraza.Waf) *Test {
 	t := &Test{
 		Name:            name,
 		transaction:     waf.NewTransaction(context.Background()),

--- a/testing/engine_test.go
+++ b/testing/engine_test.go
@@ -46,8 +46,8 @@ func TestDebug(t *testing.T) {
 	}
 	debug := test.String()
 	expected := []string{
-		"REQUEST_URI:\n-->/test",
-		"REQUEST_METHOD:\n-->OPTIONS",
+		"REQUEST_URI: /test",
+		"REQUEST_METHOD: OPTIONS",
 	}
 	for _, e := range expected {
 		if !strings.Contains(debug, e) {
@@ -93,6 +93,11 @@ func TestResponse(t *testing.T) {
 	if err := test.RunPhases(); err != nil {
 		t.Error(err)
 	}
+	/*
+		if s := test.Transaction().GetCollection(variables.ArgsPost).GetFirstString("someoutput"); s != "withvalue" {
+			t.Errorf("Expected someoutput=withvalue, got %s", s)
+		}
+	*/
 }
 
 func buildRequest(method, uri string) string {

--- a/testing/profile.go
+++ b/testing/profile.go
@@ -58,14 +58,22 @@ type Profile struct {
 }
 
 type expectedOutput struct {
-	Headers           map[string]string `yaml:"headers,omitempty"`
-	Data              interface{}       `yaml:"data,omitempty"` // Accepts array or string
-	LogContains       string            `yaml:"log_contains,omitempty"`
-	NoLogContains     string            `yaml:"no_log_contains,omitempty"`
-	ExpectError       bool              `yaml:"expect_error,omitempty"`
-	TriggeredRules    []int             `yaml:"triggered_rules,omitempty"`
-	NonTriggeredRules []int             `yaml:"non_triggered_rules,omitempty"`
-	Status            interface{}       `yaml:"status,omitempty"`
+	Headers           map[string]string     `yaml:"headers,omitempty"`
+	Data              interface{}           `yaml:"data,omitempty"` // Accepts array or string
+	LogContains       string                `yaml:"log_contains,omitempty"`
+	NoLogContains     string                `yaml:"no_log_contains,omitempty"`
+	ExpectError       bool                  `yaml:"expect_error,omitempty"`
+	TriggeredRules    []int                 `yaml:"triggered_rules,omitempty"`
+	NonTriggeredRules []int                 `yaml:"non_triggered_rules,omitempty"`
+	Status            interface{}           `yaml:"status,omitempty"`
+	Interruption      *expectedInterruption `yaml:"interruption,omitempty"`
+}
+
+type expectedInterruption struct {
+	RuleID int    `yaml:"rule_id,omitempty"`
+	Action string `yaml:"action,omitempty"`
+	Status int    `yaml:"status,omitempty"`
+	Data   string `yaml:"data,omitempty"`
 }
 
 // TestList returns a list of tests created for a profile

--- a/transaction.go
+++ b/transaction.go
@@ -814,11 +814,11 @@ func (tx *Transaction) AuditLog() *loggers.AuditLog {
 	}
 	rengine := tx.RuleEngine.String()
 
-	// al.Transaction.Request.Headers = tx.Variables.RequestHeaders).Data()
+	al.Transaction.Request.Headers = tx.Variables.RequestHeaders.Data()
 	al.Transaction.Request.Body = tx.Variables.RequestBody.String()
 	// TODO maybe change to:
 	// al.Transaction.Request.Body = tx.RequestBodyBuffer.String()
-	// al.Transaction.Response.Headers = tx.Variables.ResponseHeaders).Data()
+	al.Transaction.Response.Headers = tx.Variables.ResponseHeaders.Data()
 	al.Transaction.Response.Body = tx.Variables.ResponseBody.String()
 	al.Transaction.Producer = loggers.AuditTransactionProducer{
 		Connector:  tx.Waf.ProducerConnector,


### PR DESCRIPTION
* fix macro expansion

* Test engine for interruptions, test disruptive actions (#286)

- Enhance the test engine to perform tests of returned interruptions
  (output.interruption)

- Add testing for disruptive actions

- Enhance test output (verbose vs non-verbose, add colors, use less
  space for verbose output)

Co-authored-by: Stefan Schlesinger <sts@ono.at>

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: